### PR TITLE
Add benchmarkJoinSize which pre-allocates the []string slice

### DIFF
--- a/stringconcat_test.go
+++ b/stringconcat_test.go
@@ -134,6 +134,45 @@ func BenchmarkJoin10000(b *testing.B) {
 	benchmarkJoin(b, 10000)
 }
 
+// benchmarkJoinSize provides a benchmark for the time it takes to set
+// up an array with strings, and calling strings.Join on that array
+// to get a fully concatenated string – when the (approximate) number of
+// strings is known in advance.
+//
+// This is identical to benchmarkJoin, except numConcat is used to size
+// the []string slice's initial capacity to avoid needless reallocation.
+func benchmarkJoinSize(b *testing.B, numConcat int) {
+	// Reports memory allocations
+	b.ReportAllocs()
+
+	var ns string
+	for i := 0; i < b.N; i++ {
+		next := nextString()
+		a := make([]string, 0, numConcat)
+		for u := 0; u < numConcat; u++ {
+			a = append(a, next())
+		}
+		ns = strings.Join(a, "")
+	}
+	global = ns
+}
+
+func BenchmarkJoinSize10(b *testing.B) {
+	benchmarkJoinSize(b, 10)
+}
+
+func BenchmarkJoinSize100(b *testing.B) {
+	benchmarkJoinSize(b, 100)
+}
+
+func BenchmarkJoinSize1000(b *testing.B) {
+	benchmarkJoinSize(b, 1000)
+}
+
+func BenchmarkJoinSize10000(b *testing.B) {
+	benchmarkJoinSize(b, 10000)
+}
+
 // benchmarkBufferString
 func benchmarkBufferString(b *testing.B, numConcat int) {
 	// Reports memory allocations


### PR DESCRIPTION
`benchmarkJoin()` naïvely `append()`s strings onto a `[]string`. When the underlying slice reaches capacity, it is reallocated.

`benchmarkJoinSize()` uses numConcat to size the slice's initial capacity. This has different effects based on the relationship of this capacity number and the actual number of strings:
- If the slice is too small, it will be grown by `append()`, ultimately degenerating to `benchmarkJoin()`'s behavior.
- If the slice is too large, memory is wasted proportional to the overage.
- If the slice is sized correctly, there is no penalty at all.

This method is therefore useful outside synthetic benchmarks, in any situations where string concatenation speed is important and the caller has a guess as to the number of strings needing to be joined.

`benchmarkJoinSize` beats every other method at every size in terms of allocs/op. On my system, it's also the fastest in terms of ns/op at each size except 10000, where it loses to `BufferString` by 14%.

An updated benchmark is in my tree as 851b1e0e96bf0a7294e8b2e528cca3a96ed69c61, but is not included in this pull request.
