### PR TITLE
Avoid unnecessary conversion for append

### DIFF
--- a/stringconcat_test.go
+++ b/stringconcat_test.go
@@ -76,7 +76,7 @@ func benchmarkByteSlice(b *testing.B, numConcat int) {
 		next := nextString()
 		b := []byte{}
 		for u := 0; u < numConcat; u++ {
-			b = append(b, []byte(next())...)
+			b = append(b, next()...)
 		}
 		ns = string(b)
 	}


### PR DESCRIPTION
Both the `append` and `copy` builtins have long supported using a `string` as the src when the dst is a `[]byte`. This PR avoids an unnecessary conversion (and thus an unnecessary allocation). This is all `bytes.(*Buffer).WriteString` is doing internally (appending the string directly to the internal byte slice), and with a tiny amount of effort toward preallocation (which is also what the Buffer implementation is doing), the append benchmark could trivially be made as fast or faster than the Buffer test; any extra speed would come from avoiding the call overhead imposed by the Buffer abstraction.