### PR TITLE
various improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+
+all:
+	go test -test.bench '.*' ./...
+

--- a/README.md
+++ b/README.md
@@ -14,20 +14,32 @@ Here are how the methods tested stack up:
 And here are the raw results (also including a benchmark for byte slices):
 
 ```
-BenchmarkNaiveConcat10	  500000	      6738 ns/op	     442 B/op	      21 allocs/op
-BenchmarkNaiveConcat100	   10000	    115895 ns/op	   27736 B/op	     201 allocs/op
-BenchmarkNaiveConcat1000	     500	   4802280 ns/op	 2684216 B/op	    2001 allocs/op
-BenchmarkNaiveConcat10000	       5	 272311728 ns/op	264645752 B/op	   20001 allocs/op
-BenchmarkByteSlice10	  200000	      8674 ns/op	     432 B/op	      28 allocs/op
-BenchmarkByteSlice100	   50000	     62424 ns/op	    3440 B/op	     211 allocs/op
-BenchmarkByteSlice1000	    5000	    607276 ns/op	   48688 B/op	    2019 allocs/op
-BenchmarkByteSlice10000	     500	   5697016 ns/op	  509104 B/op	   20029 allocs/op
-BenchmarkJoin10	  200000	      8750 ns/op	     740 B/op	      19 allocs/op
-BenchmarkJoin100	   50000	     56398 ns/op	    6018 B/op	     113 allocs/op
-BenchmarkJoin1000	    5000	    484793 ns/op	   51304 B/op	    1018 allocs/op
-BenchmarkJoin10000	     500	   5896195 ns/op	 1112755 B/op	   10032 allocs/op
-BenchmarkBufferString10	  200000	      9120 ns/op	     433 B/op	      18 allocs/op
-BenchmarkBufferString100	   50000	     49411 ns/op	    2720 B/op	     111 allocs/op
-BenchmarkBufferString1000	    5000	    422961 ns/op	   23488 B/op	    1014 allocs/op
-BenchmarkBufferString10000	     500	   3842033 ns/op	  297216 B/op	   10018 allocs/op
+BenchmarkNaiveConcat10-3     	 2000000	      1192 ns/op	     360 B/op	      11 allocs/op
+BenchmarkNaiveConcat100-3    	   50000	     34117 ns/op	   26408 B/op	     101 allocs/op
+BenchmarkNaiveConcat1000-3   	     500	   2641900 ns/op	 2694414 B/op	    1004 allocs/op
+BenchmarkNaiveConcat10000-3  	      10	 188733914 ns/op	271630262 B/op	   10339 allocs/op
+BenchmarkByteSlice10-3       	 2000000	       717 ns/op	     208 B/op	       7 allocs/op
+BenchmarkByteSlice100-3      	  300000	      4000 ns/op	    1552 B/op	      10 allocs/op
+BenchmarkByteSlice1000-3     	   30000	     53874 ns/op	   26128 B/op	      16 allocs/op
+BenchmarkByteSlice10000-3    	    2000	    701131 ns/op	  283668 B/op	      24 allocs/op
+BenchmarkByteSliceSize10-3   	 3000000	       536 ns/op	     200 B/op	       4 allocs/op
+BenchmarkByteSliceSize100-3  	  300000	      3396 ns/op	    1560 B/op	       4 allocs/op
+BenchmarkByteSliceSize1000-3 	   30000	     40858 ns/op	   15896 B/op	       4 allocs/op
+BenchmarkByteSliceSize10000-3	    2000	    575724 ns/op	  163866 B/op	       4 allocs/op
+BenchmarkJoin10-3            	 1000000	      1724 ns/op	     648 B/op	       9 allocs/op
+BenchmarkJoin100-3           	  200000	      9183 ns/op	    5128 B/op	      12 allocs/op
+BenchmarkJoin1000-3          	   20000	     82654 ns/op	   43528 B/op	      15 allocs/op
+BenchmarkJoin10000-3         	    1000	   1540246 ns/op	  941844 B/op	      24 allocs/op
+BenchmarkJoinSize10-3        	 2000000	       887 ns/op	     312 B/op	       5 allocs/op
+BenchmarkJoinSize100-3       	  200000	      5981 ns/op	    2712 B/op	       5 allocs/op
+BenchmarkJoinSize1000-3      	   20000	     66210 ns/op	   27160 B/op	       5 allocs/op
+BenchmarkJoinSize10000-3     	    2000	    814003 ns/op	  278555 B/op	       5 allocs/op
+BenchmarkBufferString10-3    	 1000000	      1354 ns/op	     400 B/op	       8 allocs/op
+BenchmarkBufferString100-3   	  200000	      6410 ns/op	    2368 B/op	      11 allocs/op
+BenchmarkBufferString1000-3  	   20000	     56510 ns/op	   18880 B/op	      14 allocs/op
+BenchmarkBufferString10000-3 	    2000	    699816 ns/op	  170178 B/op	      17 allocs/op
+BenchmarkBufferSize10-3      	 2000000	       766 ns/op	     312 B/op	       5 allocs/op
+BenchmarkBufferSize100-3     	  300000	      4548 ns/op	    1672 B/op	       5 allocs/op
+BenchmarkBufferSize1000-3    	   30000	     50437 ns/op	   16008 B/op	       5 allocs/op
+BenchmarkBufferSize10000-3   	    2000	    670182 ns/op	  163978 B/op	       5 allocs/op
 ```


### PR DESCRIPTION
Hey buddy!

I bumped into this and found it very useful!

The big change is pre-allocating all the junk strings. This does two things.  most of the time
was spend into strconv, which skewed the timings.  In addition the test was really counting the `numConcat`junk string allocations instead what the string-concat algorithm was doing.

In addition I added two new tests: preallocation for byte slice, and bytes.Buffer.
As you might expect, these improve things a bit.

Thanks and enjoy!

n
